### PR TITLE
added strip_include_path to library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,4 +11,5 @@ cc_library(
     hdrs = glob([
         "include/**/*.h",
     ]),
+    strip_include_prefix = "include",
 )


### PR DESCRIPTION
removing the "include" from the header name prefix.